### PR TITLE
Add public decks retrieval functionality

### DIFF
--- a/RepetiGo.Api/Controllers/DecksController.cs
+++ b/RepetiGo.Api/Controllers/DecksController.cs
@@ -93,8 +93,22 @@ namespace RepetiGo.Api.Controllers
 
         // <summary>
         // PATCH /api/decks/{deckId}/sharing
-        // GET /api/shared/decks
         // POST /api/shared/decks/{deckId}/import
         // </summary>
+        [Authorize]
+        [HttpGet("shared")]
+        public async Task<ActionResult<ServiceResult<ICollection<DeckResponse>>>> GetPublicDecks([FromQuery] Query? query)
+        {
+            if (!ModelState.IsValid)
+            {
+                return BadRequest(ServiceResult<ICollection<DeckResponse>>.Failure(
+                    "Validation failed",
+                    HttpStatusCode.BadRequest
+                ));
+            }
+
+            var result = await _decksService.GetPublicDecksAsync(query, User);
+            return result.ToActionResult();
+        }
     }
 }

--- a/RepetiGo.Api/Interfaces/Services/IDecksService.cs
+++ b/RepetiGo.Api/Interfaces/Services/IDecksService.cs
@@ -9,5 +9,6 @@ namespace RepetiGo.Api.Interfaces.Services
         Task<ServiceResult<DeckResponse>> CreateDeckAsync(CreateDeckRequest createDeck, ClaimsPrincipal claimsPrincipal);
         Task<ServiceResult<DeckResponse>> UpdateDeckAsync(int deckId, UpdateDeckRequest updateDeckRequest, ClaimsPrincipal claimsPrincipal);
         Task<ServiceResult<object>> DeleteDeckAsync(int deckId, ClaimsPrincipal claimsPrincipal);
+        Task<ServiceResult<ICollection<DeckResponse>>> GetPublicDecksAsync(Query? query, ClaimsPrincipal claimsPrincipal);
     }
 }

--- a/RepetiGo.Api/Interfaces/Services/IDecksService.cs
+++ b/RepetiGo.Api/Interfaces/Services/IDecksService.cs
@@ -10,5 +10,6 @@ namespace RepetiGo.Api.Interfaces.Services
         Task<ServiceResult<DeckResponse>> UpdateDeckAsync(int deckId, UpdateDeckRequest updateDeckRequest, ClaimsPrincipal claimsPrincipal);
         Task<ServiceResult<object>> DeleteDeckAsync(int deckId, ClaimsPrincipal claimsPrincipal);
         Task<ServiceResult<ICollection<DeckResponse>>> GetPublicDecksAsync(Query? query, ClaimsPrincipal claimsPrincipal);
+        bool HasAccessToDeck(Deck deck, string userId);
     }
 }

--- a/RepetiGo.Api/Repositories/CardsRepository.cs
+++ b/RepetiGo.Api/Repositories/CardsRepository.cs
@@ -1,6 +1,4 @@
-﻿using RepetiGo.Api.Interfaces.Repositories;
-
-namespace RepetiGo.Api.Repositories
+﻿namespace RepetiGo.Api.Repositories
 {
     public class CardsRepository : GenericRepository<Card>, ICardsRepository
     {

--- a/RepetiGo.Api/Repositories/DecksRepository.cs
+++ b/RepetiGo.Api/Repositories/DecksRepository.cs
@@ -1,6 +1,4 @@
-﻿using RepetiGo.Api.Interfaces.Repositories;
-
-namespace RepetiGo.Api.Repositories
+﻿namespace RepetiGo.Api.Repositories
 {
     public class DecksRepository : GenericRepository<Deck>, IDecksRepository
     {

--- a/RepetiGo.Api/Repositories/ReviewsRepository.cs
+++ b/RepetiGo.Api/Repositories/ReviewsRepository.cs
@@ -1,6 +1,4 @@
-﻿using RepetiGo.Api.Interfaces.Repositories;
-
-namespace RepetiGo.Api.Repositories
+﻿namespace RepetiGo.Api.Repositories
 {
     public class ReviewsRepository : GenericRepository<Review>, IReviewsRepository
     {

--- a/RepetiGo.Api/Repositories/SettingsRepository.cs
+++ b/RepetiGo.Api/Repositories/SettingsRepository.cs
@@ -1,6 +1,4 @@
-﻿using RepetiGo.Api.Interfaces.Repositories;
-
-namespace RepetiGo.Api.Repositories
+﻿namespace RepetiGo.Api.Repositories
 {
     public class SettingsRepository : GenericRepository<Settings>, ISettingsRepository
     {

--- a/RepetiGo.Api/Repositories/UnitOfWork.cs
+++ b/RepetiGo.Api/Repositories/UnitOfWork.cs
@@ -1,7 +1,4 @@
-﻿using RepetiGo.Api.Interfaces;
-using RepetiGo.Api.Interfaces.Repositories;
-
-namespace RepetiGo.Api.Repositories
+﻿namespace RepetiGo.Api.Repositories
 {
     public class UnitOfWork : IUnitOfWork
     {

--- a/RepetiGo.Api/Services/CardsService.cs
+++ b/RepetiGo.Api/Services/CardsService.cs
@@ -14,8 +14,9 @@ namespace RepetiGo.Api.Services
         private readonly ILogger<CardsService> _logger;
         private readonly IAiGeneratorService _aiGeneratorService;
         private readonly IReviewsService _reviewsService;
+        private readonly IDecksService _decksService;
 
-        public CardsService(IUnitOfWork unitOfWork, IMapper mapper, IUploadsService uploadsService, ILogger<CardsService> logger, IAiGeneratorService aiGeneratorService, IReviewsService reviewsService)
+        public CardsService(IUnitOfWork unitOfWork, IMapper mapper, IUploadsService uploadsService, ILogger<CardsService> logger, IAiGeneratorService aiGeneratorService, IReviewsService reviewsService, IDecksService decksService)
         {
             _unitOfWork = unitOfWork;
             _mapper = mapper;
@@ -23,6 +24,7 @@ namespace RepetiGo.Api.Services
             _logger = logger;
             _aiGeneratorService = aiGeneratorService;
             _reviewsService = reviewsService;
+            _decksService = decksService;
         }
 
         public async Task<ServiceResult<ICollection<CardResponse>>> GetCardsByDeckIdAsync(int deckId, Query? query, ClaimsPrincipal claimsPrincipal)
@@ -45,7 +47,7 @@ namespace RepetiGo.Api.Services
                 );
             }
 
-            if (deck.UserId != userId && deck.Visibility != CardVisibility.Public)
+            if (!_decksService.HasAccessToDeck(deck, userId))
             {
                 return ServiceResult<ICollection<CardResponse>>.Failure(
                     "You do not have permission to access this deck",
@@ -82,7 +84,7 @@ namespace RepetiGo.Api.Services
                 );
             }
 
-            if (deck.UserId != userId && deck.Visibility != CardVisibility.Public)
+            if (!_decksService.HasAccessToDeck(deck, userId))
             {
                 return ServiceResult<CardResponse>.Failure(
                     "You do not have permission to access this deck",

--- a/RepetiGo.Api/Services/CardsService.cs
+++ b/RepetiGo.Api/Services/CardsService.cs
@@ -45,7 +45,7 @@ namespace RepetiGo.Api.Services
                 );
             }
 
-            if (deck.UserId != userId)
+            if (deck.UserId != userId && deck.Visibility != CardVisibility.Public)
             {
                 return ServiceResult<ICollection<CardResponse>>.Failure(
                     "You do not have permission to access this deck",
@@ -82,7 +82,7 @@ namespace RepetiGo.Api.Services
                 );
             }
 
-            if (deck.UserId != userId)
+            if (deck.UserId != userId && deck.Visibility != CardVisibility.Public)
             {
                 return ServiceResult<CardResponse>.Failure(
                     "You do not have permission to access this deck",

--- a/RepetiGo.Api/Services/DecksService.cs
+++ b/RepetiGo.Api/Services/DecksService.cs
@@ -50,6 +50,34 @@ namespace RepetiGo.Api.Services
             return ServiceResult<ICollection<DeckResponse>>.Success(decksResponse);
         }
 
+        public async Task<ServiceResult<ICollection<DeckResponse>>> GetPublicDecksAsync(Query? query, ClaimsPrincipal claimsPrincipal)
+        {
+            var userId = claimsPrincipal.FindFirstValue(ClaimTypes.NameIdentifier);
+            if (string.IsNullOrEmpty(userId))
+            {
+                return ServiceResult<ICollection<DeckResponse>>.Failure(
+                    "User not authenticated",
+                    HttpStatusCode.Unauthorized
+                );
+            }
+
+            var user = await _userManager.FindByIdAsync(userId);
+            if (user is null)
+            {
+                return ServiceResult<ICollection<DeckResponse>>.Failure(
+                    "User not found",
+                    HttpStatusCode.NotFound
+                );
+            }
+
+            var decks = await _unitOfWork.DecksRepository.GetAllAsync(
+                filter: d => d.Visibility == CardVisibility.Public,
+                query: query);
+
+            var decksResponse = _mapper.Map<ICollection<DeckResponse>>(decks);
+            return ServiceResult<ICollection<DeckResponse>>.Success(decksResponse);
+        }
+
         public async Task<ServiceResult<DeckResponse>> GetDeckByIdAsync(int deckId, ClaimsPrincipal claimsPrincipal)
         {
             var userId = claimsPrincipal.FindFirstValue(ClaimTypes.NameIdentifier);
@@ -70,7 +98,7 @@ namespace RepetiGo.Api.Services
                 );
             }
 
-            if (deck.UserId != userId)
+            if (deck.UserId != userId && deck.Visibility != CardVisibility.Public)
             {
                 return ServiceResult<DeckResponse>.Failure(
                     "You do not have permission to access this deck",

--- a/RepetiGo.Api/Services/DecksService.cs
+++ b/RepetiGo.Api/Services/DecksService.cs
@@ -98,7 +98,7 @@ namespace RepetiGo.Api.Services
                 );
             }
 
-            if (deck.UserId != userId && deck.Visibility != CardVisibility.Public)
+            if (!HasAccessToDeck(deck, userId))
             {
                 return ServiceResult<DeckResponse>.Failure(
                     "You do not have permission to access this deck",
@@ -246,6 +246,11 @@ namespace RepetiGo.Api.Services
                 new { Message = "Deck deleted successfully" },
                 HttpStatusCode.NoContent
             );
+        }
+
+        public bool HasAccessToDeck(Deck deck, string userId)
+        {
+            return deck.UserId == userId || deck.Visibility == CardVisibility.Public;
         }
     }
 }

--- a/RepetiGo.Api/Services/SettingsService.cs
+++ b/RepetiGo.Api/Services/SettingsService.cs
@@ -1,6 +1,4 @@
-﻿using RepetiGo.Api.Interfaces;
-
-namespace RepetiGo.Api.Services
+﻿namespace RepetiGo.Api.Services
 {
     public class SettingsService : ISettingsService
     {


### PR DESCRIPTION
- Implemented `GetPublicDecks` endpoint in `DecksController.cs`.
- Updated `IDecksService` with `GetPublicDecksAsync` method.
- Cleaned up unnecessary `using` statements in multiple repository files.
- Enhanced `CardsService.cs` to check for user ownership and public visibility.
- Added logic for public decks retrieval in `DecksService.cs`.
- Refined namespace declarations in `SettingsService.cs`.