### PR TITLE
Add deck cloning feature and update related services

### DIFF
--- a/RepetiGo.Api.Tests/RepetiGo.Api.Tests.csproj
+++ b/RepetiGo.Api.Tests/RepetiGo.Api.Tests.csproj
@@ -1,0 +1,33 @@
+﻿<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <TargetFramework>net9.0</TargetFramework>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <Nullable>enable</Nullable>
+    <IsPackable>false</IsPackable>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="coverlet.collector" Version="6.0.4">
+      <PrivateAssets>all</PrivateAssets>
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+    </PackageReference>
+    <PackageReference Include="FluentAssertions" Version="8.3.0" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.14.1" />
+    <PackageReference Include="Moq" Version="4.20.72" />
+    <PackageReference Include="xunit" Version="2.9.3" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="3.1.1">
+      <PrivateAssets>all</PrivateAssets>
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+    </PackageReference>
+  </ItemGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\RepetiGo.Api\RepetiGo.Api.csproj" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <Using Include="Xunit" />
+  </ItemGroup>
+
+</Project>

--- a/RepetiGo.Api.Tests/ReviewsServiceTests.cs
+++ b/RepetiGo.Api.Tests/ReviewsServiceTests.cs
@@ -1,0 +1,358 @@
+﻿using AutoMapper;
+
+using FluentAssertions;
+
+using Moq;
+
+using RepetiGo.Api.Enums;
+using RepetiGo.Api.Interfaces.Repositories;
+using RepetiGo.Api.MappingProfiles;
+using RepetiGo.Api.Models;
+using RepetiGo.Api.Services;
+
+namespace RepetiGo.Api.Tests
+{
+    public class ReviewsServiceTests
+    {
+        private readonly Mock<IUnitOfWork> _mockUnitOfWork;
+        private readonly Mock<ICardsRepository> _mockCardsRepository;
+        private readonly IMapper _mapper;
+        private readonly ReviewsService _reviewService;
+        private readonly Settings _defaultSettings;
+
+        public ReviewsServiceTests()
+        {
+            _mockUnitOfWork = new Mock<IUnitOfWork>();
+            _mockCardsRepository = new Mock<ICardsRepository>();
+            _mockUnitOfWork.Setup(uow => uow.CardsRepository).Returns(_mockCardsRepository.Object);
+
+            var mapperConfig = new MapperConfiguration(cfg =>
+            {
+                cfg.AddProfile<ReviewMappingProfile>();
+            });
+            _mapper = mapperConfig.CreateMapper();
+
+            _reviewService = new ReviewsService(_mockUnitOfWork.Object, _mapper);
+
+            _defaultSettings = new Settings
+            {
+                LearningSteps = "25m 1d",
+                RelearningSteps = "30m",
+                GraduatingInterval = 3,
+                EasyInterval = 4,
+                MinimumInterval = 1,
+                MaximumInterval = 180,
+                EasyBonus = 1.5,
+                HardInterval = 1.2,
+                NewInterval = 0.2
+            };
+        }
+
+        [Fact]
+        public async Task ProcessReview_NewCard_Again_ShouldResetToFirstLearningStep()
+        {
+            // Arrange
+            var card = new Card
+            {
+                Id = 1,
+                Status = CardStatus.New,
+                LearningStep = 0,
+                NextReview = DateTime.UtcNow
+            };
+            // Tell the mock repository what to do when UpdateAsync is called
+            // It.IsAny<Card>() means "accept any Card object"
+            // Returns(Task.CompletedTask) means "return a completed task"
+            _mockCardsRepository.Setup(c => c.UpdateAsync(It.IsAny<Card>())).Returns(Task.CompletedTask);
+            // Tell the mock repository what to do when GetByIdAsync is called
+            // ReturnsAsync(1) means "return a task that completes with the value 1"
+            _mockUnitOfWork.Setup(uow => uow.SaveAsync()).ReturnsAsync(1);
+
+            // Act
+            await _reviewService.ProcessReview(card, ReviewRating.Again, _defaultSettings);
+
+            // Assert
+            card.NextReview.Should().BeCloseTo(DateTime.UtcNow.AddMinutes(25), TimeSpan.FromSeconds(1));
+            card.Repetition.Should().Be(0);
+            card.Status.Should().Be(CardStatus.Learning);
+            card.EasinessFactor.Should().Be(2.5);
+            card.LearningStep.Should().Be(0);
+            card.FailedInterval.Should().BeNull();
+            card.LastReviewed.Should().BeCloseTo(DateTime.UtcNow, TimeSpan.FromSeconds(1));
+        }
+
+        [Fact]
+        public async Task ProcessReview_NewCard_Hard_ShouldAdvanceToNextLearningStep()
+        {
+            // Arrange
+            var card = new Card
+            {
+                Id = 1,
+                Status = CardStatus.New,
+                LearningStep = 0,
+                NextReview = DateTime.UtcNow
+            };
+            _mockCardsRepository.Setup(c => c.UpdateAsync(It.IsAny<Card>())).Returns(Task.CompletedTask);
+            _mockUnitOfWork.Setup(uow => uow.SaveAsync()).ReturnsAsync(1);
+
+            // Act
+            await _reviewService.ProcessReview(card, ReviewRating.Hard, _defaultSettings);
+
+            // Assert
+            card.NextReview.Should().BeCloseTo(DateTime.UtcNow.AddDays(1), TimeSpan.FromSeconds(1));
+            card.Repetition.Should().Be(0);
+            card.Status.Should().Be(CardStatus.Learning);
+            card.EasinessFactor.Should().Be(2.5);
+            card.LearningStep.Should().Be(1);
+            card.FailedInterval.Should().BeNull();
+            card.LastReviewed.Should().BeCloseTo(DateTime.UtcNow, TimeSpan.FromSeconds(1));
+        }
+
+        [Fact]
+        public async Task ProcessReview_NewCard_Good_ShouldAdvanceToNextLearningStep()
+        {
+            // Arrange
+            var card = new Card
+            {
+                Id = 1,
+                Status = CardStatus.New,
+                LearningStep = 0,
+                NextReview = DateTime.UtcNow
+            };
+            _mockCardsRepository.Setup(c => c.UpdateAsync(It.IsAny<Card>())).Returns(Task.CompletedTask);
+            _mockUnitOfWork.Setup(uow => uow.SaveAsync()).ReturnsAsync(1);
+
+            // Act
+            await _reviewService.ProcessReview(card, ReviewRating.Good, _defaultSettings);
+
+            // Assert
+            card.NextReview.Should().BeCloseTo(DateTime.UtcNow.AddDays(1), TimeSpan.FromSeconds(1));
+            card.Repetition.Should().Be(0);
+            card.Status.Should().Be(CardStatus.Learning);
+            card.EasinessFactor.Should().Be(2.5);
+            card.LearningStep.Should().Be(1);
+            card.FailedInterval.Should().BeNull();
+            card.LastReviewed.Should().BeCloseTo(DateTime.UtcNow, TimeSpan.FromSeconds(1));
+        }
+
+        [Fact]
+        public async Task ProcessReview_NewCard_Easy_ShouldGraduateToReview()
+        {
+            // Arrange
+            var card = new Card
+            {
+                Id = 1,
+                Status = CardStatus.New,
+                LearningStep = 0,
+                NextReview = DateTime.UtcNow
+            };
+            _mockCardsRepository.Setup(c => c.UpdateAsync(It.IsAny<Card>())).Returns(Task.CompletedTask);
+            _mockUnitOfWork.Setup(uow => uow.SaveAsync()).ReturnsAsync(1);
+
+            // Act
+            await _reviewService.ProcessReview(card, ReviewRating.Easy, _defaultSettings);
+
+            // Assert
+            card.NextReview.Should().BeCloseTo(DateTime.UtcNow.AddDays(4), TimeSpan.FromSeconds(1));
+            card.Repetition.Should().Be(1);
+            card.Status.Should().Be(CardStatus.Review);
+            card.EasinessFactor.Should().Be(2.65);
+            card.LearningStep.Should().Be(1);
+            card.FailedInterval.Should().BeNull();
+            card.LastReviewed.Should().BeCloseTo(DateTime.UtcNow, TimeSpan.FromSeconds(1));
+        }
+
+        [Fact]
+        public async Task ProcessReview_LearningCard_Again_ShouldResetToFirstStep()
+        {
+            // Arrange
+            var card = new Card
+            {
+                Id = 1,
+                Status = CardStatus.Learning,
+                LearningStep = 1,
+                NextReview = DateTime.UtcNow,
+                Repetition = 0,
+                EasinessFactor = 2.5
+            };
+            _mockCardsRepository.Setup(c => c.UpdateAsync(It.IsAny<Card>())).Returns(Task.CompletedTask);
+            _mockUnitOfWork.Setup(uow => uow.SaveAsync()).ReturnsAsync(1);
+
+            // Act
+            await _reviewService.ProcessReview(card, ReviewRating.Again, _defaultSettings);
+
+            // Assert
+            card.NextReview.Should().BeCloseTo(DateTime.UtcNow.AddMinutes(25), TimeSpan.FromSeconds(1));
+            card.Repetition.Should().Be(0);
+            card.Status.Should().Be(CardStatus.Learning);
+            card.EasinessFactor.Should().Be(2.5);
+            card.LearningStep.Should().Be(0);
+            card.FailedInterval.Should().BeNull();
+            card.LastReviewed.Should().BeCloseTo(DateTime.UtcNow, TimeSpan.FromSeconds(1));
+        }
+
+        [Fact]
+        public async Task ProcessReview_LearningCard_Good_LastStep_ShouldGraduateToReview()
+        {
+            // Arrange
+            var card = new Card
+            {
+                Id = 1,
+                Status = CardStatus.Learning,
+                LearningStep = 1,
+                NextReview = DateTime.UtcNow,
+                Repetition = 0,
+                EasinessFactor = 2.5
+            };
+            _mockCardsRepository.Setup(c => c.UpdateAsync(It.IsAny<Card>())).Returns(Task.CompletedTask);
+            _mockUnitOfWork.Setup(uow => uow.SaveAsync()).ReturnsAsync(1);
+
+            // Act
+            await _reviewService.ProcessReview(card, ReviewRating.Good, _defaultSettings);
+
+            // Assert
+            card.NextReview.Should().BeCloseTo(DateTime.UtcNow.AddDays(3), TimeSpan.FromSeconds(1));
+            card.Repetition.Should().Be(1);
+            card.Status.Should().Be(CardStatus.Review);
+            card.EasinessFactor.Should().Be(2.5);
+            card.LearningStep.Should().Be(1);
+            card.FailedInterval.Should().BeNull();
+            card.LastReviewed.Should().BeCloseTo(DateTime.UtcNow, TimeSpan.FromSeconds(1));
+        }
+
+        [Fact]
+        public async Task ProcessReview_ReviewCard_Again_ShouldResetToRelearning()
+        {
+            // Arrange
+            var card = new Card
+            {
+                Id = 1,
+                Status = CardStatus.Review,
+                NextReview = DateTime.UtcNow,
+                Repetition = 5,
+                LastReviewed = DateTime.UtcNow.AddDays(-10),
+                EasinessFactor = 2.5
+            };
+            _mockCardsRepository.Setup(c => c.UpdateAsync(It.IsAny<Card>())).Returns(Task.CompletedTask);
+            _mockUnitOfWork.Setup(uow => uow.SaveAsync()).ReturnsAsync(1);
+
+            // Act
+            await _reviewService.ProcessReview(card, ReviewRating.Again, _defaultSettings);
+
+            // Assert
+            card.NextReview.Should().BeCloseTo(DateTime.UtcNow.AddMinutes(30), TimeSpan.FromSeconds(1));
+            card.Repetition.Should().Be(0);
+            card.Status.Should().Be(CardStatus.Relearning);
+            card.EasinessFactor.Should().BeApproximately(2.18, 0.01);
+            card.LearningStep.Should().Be(0);
+            card.FailedInterval.Should().BeApproximately(10 * _defaultSettings.NewInterval, 0.01);
+            card.LastReviewed.Should().BeCloseTo(DateTime.UtcNow, TimeSpan.FromSeconds(1));
+        }
+
+        [Fact]
+        public async Task ProcessReview_ReviewCard_Good_FirstReview_ShouldUseGraduatingInterval()
+        {
+            // Arrange
+            var card = new Card
+            {
+                Id = 1,
+                Status = CardStatus.Review,
+                NextReview = DateTime.UtcNow,
+                Repetition = 0,
+                LastReviewed = DateTime.UtcNow.AddDays(-10),
+                LearningStep = 1,
+                EasinessFactor = 2.5
+            };
+            _mockCardsRepository.Setup(c => c.UpdateAsync(It.IsAny<Card>())).Returns(Task.CompletedTask);
+            _mockUnitOfWork.Setup(uow => uow.SaveAsync()).ReturnsAsync(1);
+
+            // Act
+            await _reviewService.ProcessReview(card, ReviewRating.Good, _defaultSettings);
+
+            // Assert
+            card.NextReview.Should().BeCloseTo(DateTime.UtcNow.AddDays(3), TimeSpan.FromSeconds(1));
+            card.Repetition.Should().Be(1);
+            card.Status.Should().Be(CardStatus.Review);
+            card.EasinessFactor.Should().Be(2.5);
+            card.LearningStep.Should().Be(1);
+            card.FailedInterval.Should().BeNull();
+            card.LastReviewed.Should().BeCloseTo(DateTime.UtcNow, TimeSpan.FromSeconds(1));
+        }
+
+        [Fact]
+        public async Task ProcessReview_ReviewCard_Good_SecondReview_ShouldUseEasinessFactor()
+        {
+            // Arrange
+            var card = new Card
+            {
+                Id = 1,
+                Status = CardStatus.Review,
+                NextReview = DateTime.UtcNow,
+                Repetition = 1,
+                LastReviewed = DateTime.UtcNow.AddDays(-10),
+                LearningStep = 1,
+                EasinessFactor = 2.5
+            };
+            _mockCardsRepository.Setup(c => c.UpdateAsync(It.IsAny<Card>())).Returns(Task.CompletedTask);
+            _mockUnitOfWork.Setup(uow => uow.SaveAsync()).ReturnsAsync(1);
+
+            // Act
+            await _reviewService.ProcessReview(card, ReviewRating.Good, _defaultSettings);
+
+            // Assert
+            card.NextReview.Should().BeCloseTo(DateTime.UtcNow.AddDays(7.5), TimeSpan.FromSeconds(1));
+            card.Repetition.Should().Be(2);
+            card.Status.Should().Be(CardStatus.Review);
+            card.EasinessFactor.Should().BeApproximately(2.5, 0.01);
+            card.LearningStep.Should().Be(1);
+            card.FailedInterval.Should().BeNull();
+            card.LastReviewed.Should().BeCloseTo(DateTime.UtcNow, TimeSpan.FromSeconds(1));
+        }
+
+        [Fact]
+        public async Task ProcessReview_ReviewCard_Hard_ShouldApplyHardInterval()
+        {
+            // Arrange
+            var card = new Card
+            {
+                Id = 1,
+                Status = CardStatus.Review,
+                NextReview = DateTime.UtcNow,
+                Repetition = 1,
+                LastReviewed = DateTime.UtcNow.AddDays(-10),
+                LearningStep = 1,
+                EasinessFactor = 2.5
+            };
+            _mockCardsRepository.Setup(c => c.UpdateAsync(It.IsAny<Card>())).Returns(Task.CompletedTask);
+            _mockUnitOfWork.Setup(uow => uow.SaveAsync()).ReturnsAsync(1);
+
+            // Act
+            await _reviewService.ProcessReview(card, ReviewRating.Hard, _defaultSettings);
+
+            // Assert
+            card.NextReview.Should().BeCloseTo(DateTime.UtcNow.AddDays(12), TimeSpan.FromSeconds(1));
+            card.Repetition.Should().Be(2);
+            card.Status.Should().Be(CardStatus.Review);
+            card.EasinessFactor.Should().BeApproximately(2.36, 0.01);
+            card.LearningStep.Should().Be(1);
+            card.FailedInterval.Should().BeNull();
+            card.LastReviewed.Should().BeCloseTo(DateTime.UtcNow, TimeSpan.FromSeconds(1));
+        }
+
+        /// <summary>
+        /// ProcessReview_ReviewCard_Easy_ShouldApplyEasyBonus
+        /// ProcessReview_RelearningCard_Good_ShouldUseFailedInterval
+        /// ProcessReview_RelearningCard_Easy_ShouldUseEasyInterval
+        /// ProcessReview_EmptyLearningSteps_ShouldUseMinimumInterval
+        /// ProcessReview_EmptyRelearningSteps_ShouldUseMinimumInterval
+        /// ProcessReview_IntervalClamping_ShouldRespectMinimumAndMaximum
+        /// ProcessReview_EasinessFactorUpdate_ShouldFollowSM2Algorithm
+        /// ProcessReview_EasinessFactorUpdate_EasyRating_ShouldIncrease
+        /// ProcessReview_EasinessFactorUpdate_HardRating_ShouldDecrease
+        /// ProcessReview_EasinessFactorUpdate_AgainRating_ShouldDecreaseSignificantly
+        /// ProcessReview_EasinessFactorMinimum_ShouldNotGoBelow1_3
+        /// ProcessPreviewReviews_ShouldReturnCorrectReviewResponses
+        /// ParseSteps_ShouldHandleValidFormats
+        /// ParseSteps_ShouldThrowOnInvalidFormat
+        /// </summary>
+    }
+}

--- a/RepetiGo.Api/Controllers/DecksController.cs
+++ b/RepetiGo.Api/Controllers/DecksController.cs
@@ -91,10 +91,6 @@ namespace RepetiGo.Api.Controllers
             return result.ToActionResult();
         }
 
-        // <summary>
-        // PATCH /api/decks/{deckId}/sharing
-        // POST /api/shared/decks/{deckId}/import
-        // </summary>
         [HttpGet("shared")]
         public async Task<ActionResult<ServiceResult<ICollection<DeckResponse>>>> GetPublicDecks([FromQuery] Query? query)
         {
@@ -107,6 +103,21 @@ namespace RepetiGo.Api.Controllers
             }
 
             var result = await _decksService.GetPublicDecksAsync(query, User);
+            return result.ToActionResult();
+        }
+
+        [HttpPost("shared/{deckId:int}/clone")]
+        public async Task<ActionResult<ServiceResult<DeckResponse>>> CloneSharedDeck([FromRoute] int deckId, UpdateDeckRequest updateDeckRequest)
+        {
+            if (!ModelState.IsValid)
+            {
+                return BadRequest(ServiceResult<DeckResponse>.Failure(
+                    "Validation failed",
+                    HttpStatusCode.BadRequest
+                ));
+            }
+
+            var result = await _decksService.CloneSharedDeckAsync(deckId, updateDeckRequest, User);
             return result.ToActionResult();
         }
     }

--- a/RepetiGo.Api/Data/Migrations/20250629032236_AddCoreTables.Designer.cs
+++ b/RepetiGo.Api/Data/Migrations/20250629032236_AddCoreTables.Designer.cs
@@ -12,7 +12,7 @@ using RepetiGo.Api.Data;
 namespace RepetiGo.Api.Data.Migrations
 {
     [DbContext(typeof(ApplicationDbContext))]
-    [Migration("20250624153407_AddCoreTables")]
+    [Migration("20250629032236_AddCoreTables")]
     partial class AddCoreTables
     {
         /// <inheritdoc />
@@ -317,13 +317,16 @@ namespace RepetiGo.Api.Data.Migrations
                         .HasMaxLength(500)
                         .HasColumnType("nvarchar(500)");
 
+                    b.Property<int>("Downloads")
+                        .HasColumnType("int");
+
+                    b.Property<string>("ForkedFromUsername")
+                        .HasColumnType("nvarchar(max)");
+
                     b.Property<string>("Name")
                         .IsRequired()
                         .HasMaxLength(100)
                         .HasColumnType("nvarchar(100)");
-
-                    b.Property<int>("Ratings")
-                        .HasColumnType("int");
 
                     b.Property<DateTime?>("UpdatedAt")
                         .HasColumnType("datetime2");

--- a/RepetiGo.Api/Data/Migrations/20250629032236_AddCoreTables.cs
+++ b/RepetiGo.Api/Data/Migrations/20250629032236_AddCoreTables.cs
@@ -169,7 +169,8 @@ namespace RepetiGo.Api.Data.Migrations
                     Name = table.Column<string>(type: "nvarchar(100)", maxLength: 100, nullable: false),
                     Description = table.Column<string>(type: "nvarchar(500)", maxLength: 500, nullable: true),
                     Visibility = table.Column<int>(type: "int", nullable: false),
-                    Ratings = table.Column<int>(type: "int", nullable: false),
+                    Downloads = table.Column<int>(type: "int", nullable: false),
+                    ForkedFromUsername = table.Column<string>(type: "nvarchar(max)", nullable: true),
                     CreatedAt = table.Column<DateTime>(type: "datetime2", nullable: false, defaultValueSql: "GETUTCDATE()"),
                     UpdatedAt = table.Column<DateTime>(type: "datetime2", nullable: true),
                     UserId = table.Column<string>(type: "nvarchar(450)", nullable: false)

--- a/RepetiGo.Api/Data/Migrations/ApplicationDbContextModelSnapshot.cs
+++ b/RepetiGo.Api/Data/Migrations/ApplicationDbContextModelSnapshot.cs
@@ -314,13 +314,16 @@ namespace RepetiGo.Api.Data.Migrations
                         .HasMaxLength(500)
                         .HasColumnType("nvarchar(500)");
 
+                    b.Property<int>("Downloads")
+                        .HasColumnType("int");
+
+                    b.Property<string>("ForkedFromUsername")
+                        .HasColumnType("nvarchar(max)");
+
                     b.Property<string>("Name")
                         .IsRequired()
                         .HasMaxLength(100)
                         .HasColumnType("nvarchar(100)");
-
-                    b.Property<int>("Ratings")
-                        .HasColumnType("int");
 
                     b.Property<DateTime?>("UpdatedAt")
                         .HasColumnType("datetime2");

--- a/RepetiGo.Api/Dtos/DeckDtos/DeckResponse.cs
+++ b/RepetiGo.Api/Dtos/DeckDtos/DeckResponse.cs
@@ -6,7 +6,8 @@
         public string Name { get; set; } = string.Empty;
         public string? Description { get; set; }
         public CardVisibility Visibility { get; set; } = CardVisibility.Public;
-        public int Ratings { get; set; } = 0;
+        public int Downloads { get; set; } = 0;
+        public string? ForkedFromUsername { get; set; }
         public DateTime CreatedAt { get; set; }
         public DateTime? UpdatedAt { get; set; }
         public string UserId { get; set; } = string.Empty;

--- a/RepetiGo.Api/Interfaces/Services/IDecksService.cs
+++ b/RepetiGo.Api/Interfaces/Services/IDecksService.cs
@@ -11,5 +11,6 @@ namespace RepetiGo.Api.Interfaces.Services
         Task<ServiceResult<object>> DeleteDeckAsync(int deckId, ClaimsPrincipal claimsPrincipal);
         Task<ServiceResult<ICollection<DeckResponse>>> GetPublicDecksAsync(Query? query, ClaimsPrincipal claimsPrincipal);
         bool HasAccessToDeck(Deck deck, string userId);
+        Task<ServiceResult<DeckResponse>> CloneSharedDeckAsync(int deckId, UpdateDeckRequest updateDeckRequest, ClaimsPrincipal claimsPrincipal);
     }
 }

--- a/RepetiGo.Api/Interfaces/Services/IUploadsService.cs
+++ b/RepetiGo.Api/Interfaces/Services/IUploadsService.cs
@@ -7,5 +7,6 @@ namespace RepetiGo.Api.Interfaces.Services
         Task<ImageUploadResponse> UploadImageAsync(IFormFile formFile);
         Task<ImageUploadResponse> UploadImageAsync(byte[] bytes);
         Task<ImageUploadResponse> DeleteImageAsync(string oldAvatarPublicId);
+        Task<ImageUploadResponse> CopyImageAsync(string imageUrlSource);
     }
 }

--- a/RepetiGo.Api/Models/Deck.cs
+++ b/RepetiGo.Api/Models/Deck.cs
@@ -12,7 +12,9 @@
 
         public CardVisibility Visibility { get; set; } = CardVisibility.Public;
 
-        public int Ratings { get; set; } = 0;
+        public int Downloads { get; set; } = 0;
+
+        public string? ForkedFromUsername { get; set; }
 
         public DateTime CreatedAt { get; set; }
 

--- a/RepetiGo.Api/Services/DecksService.cs
+++ b/RepetiGo.Api/Services/DecksService.cs
@@ -337,7 +337,7 @@ namespace RepetiGo.Api.Services
                 }
             }
 
-            // Increment downloads for the original dec
+            // Increment downloads for the original deck
             deck.Downloads++;
 
             await _unitOfWork.DecksRepository.UpdateAsync(deck);

--- a/RepetiGo.Api/Services/ReviewsService.cs
+++ b/RepetiGo.Api/Services/ReviewsService.cs
@@ -57,9 +57,9 @@ namespace RepetiGo.Api.Services
                 {
                     card.NextReview = now.AddDays(settings.EasyInterval);
                     card.EasinessFactor += 0.15;
-
                     card.Status = CardStatus.Review;
                     card.Repetition = 1;
+                    card.LearningStep = steps.Count - 1;
                 }
                 else if (card.LearningStep < steps.Count - 1) // Still in learning steps
                 {
@@ -80,6 +80,7 @@ namespace RepetiGo.Api.Services
 
                     card.Status = CardStatus.Review;
                     card.Repetition = 1;
+                    card.LearningStep = steps.Count - 1;
                 }
             }
         }

--- a/RepetiGo.Api/Services/UploadsService.cs
+++ b/RepetiGo.Api/Services/UploadsService.cs
@@ -23,6 +23,42 @@ namespace RepetiGo.Api.Services
             _cloudinary = new Cloudinary(account);
         }
 
+        public async Task<ImageUploadResponse> CopyImageAsync(string imageUrlSource)
+        {
+            if (string.IsNullOrEmpty(imageUrlSource))
+            {
+                return new ImageUploadResponse
+                {
+                    IsSuccess = false,
+                    ErrorMessage = "Public ID is required for copying."
+                };
+            }
+
+            var uploadParams = new ImageUploadParams
+            {
+
+                File = new FileDescription(imageUrlSource),
+                UploadPreset = _cloudinaryConfig.UploadPreset,
+            };
+
+            var copyResult = await _cloudinary.UploadAsync(uploadParams);
+            if (copyResult.Error is not null)
+            {
+                return new ImageUploadResponse
+                {
+                    IsSuccess = false,
+                    ErrorMessage = copyResult.Error.Message
+                };
+            }
+
+            return new ImageUploadResponse
+            {
+                IsSuccess = true,
+                SecureUrl = copyResult.SecureUrl.ToString(),
+                PublicId = copyResult.PublicId
+            };
+        }
+
         public async Task<ImageUploadResponse> DeleteImageAsync(string oldAvatarPublicId)
         {
             if (string.IsNullOrEmpty(oldAvatarPublicId))
@@ -33,6 +69,7 @@ namespace RepetiGo.Api.Services
                     ErrorMessage = "Public ID is required for deletion."
                 };
             }
+
             var deleteParams = new DeletionParams(oldAvatarPublicId);
             var deletionResult = await _cloudinary.DestroyAsync(deleteParams);
             return new ImageUploadResponse

--- a/RepetiGo.sln
+++ b/RepetiGo.sln
@@ -5,6 +5,8 @@ VisualStudioVersion = 17.14.36121.58
 MinimumVisualStudioVersion = 10.0.40219.1
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "RepetiGo.Api", "RepetiGo.Api\RepetiGo.Api.csproj", "{7AE8A532-6441-5FB4-BF57-BCF5AEFC2B3D}"
 EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "RepetiGo.Api.Tests", "RepetiGo.Api.Tests\RepetiGo.Api.Tests.csproj", "{C1E7E6B9-797C-4F91-9590-2E3AC2670D90}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -15,6 +17,10 @@ Global
 		{7AE8A532-6441-5FB4-BF57-BCF5AEFC2B3D}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{7AE8A532-6441-5FB4-BF57-BCF5AEFC2B3D}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{7AE8A532-6441-5FB4-BF57-BCF5AEFC2B3D}.Release|Any CPU.Build.0 = Release|Any CPU
+		{C1E7E6B9-797C-4F91-9590-2E3AC2670D90}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{C1E7E6B9-797C-4F91-9590-2E3AC2670D90}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{C1E7E6B9-797C-4F91-9590-2E3AC2670D90}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{C1E7E6B9-797C-4F91-9590-2E3AC2670D90}.Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE


### PR DESCRIPTION
- Implemented a new endpoint in `DecksController` for cloning shared decks, including user validation and image copying.
- Updated `IDecksService` and `IUploadsService` interfaces to support new methods for cloning and image copying.
- Modified `Deck` model and `DeckResponse` to include `Downloads` and `ForkedFromUsername`, removing `Ratings`.
- Adjusted `DecksService` and `ReviewsService` logic to accommodate new features and ensure proper review processing.
- Added unit tests for `ReviewsService` and created a new test project `RepetiGo.Api.Tests`.
- Cleaned up migration files and updated the database schema to reflect the new properties.